### PR TITLE
Fix rounding error with Ruby 2.4

### DIFF
--- a/lib/uob/payroll/txt_file/row.rb
+++ b/lib/uob/payroll/txt_file/row.rb
@@ -36,7 +36,7 @@ module UOB
       end
 
       def formatted_amount
-        (format '%014.2f', amount).gsub('.','')
+        (format '%014.2f', amount.round(2)).gsub('.','')
       end
 
       def receiving_bic_code

--- a/lib/uob/payroll/txt_file/row.rb
+++ b/lib/uob/payroll/txt_file/row.rb
@@ -30,7 +30,7 @@ module UOB
         @bic_code = bic_code
         @account_number = account_number
         @account_name = account_name
-        @amount = amount
+        @amount = amount.is_a?(String) ? BigDecimal(amount) : amount
 
         raise Errors::Invalid, errors.full_messages.to_sentence unless valid?
       end

--- a/spec/uob/payroll/txt_file/row_spec.rb
+++ b/spec/uob/payroll/txt_file/row_spec.rb
@@ -4,13 +4,14 @@ describe UOB::Payroll::TXTFile::Row do
 
   subject(:row) { described_class.new params }
   let(:string_version) { row.to_s }
+  let(:amount) { 43.35 }
 
   let(:params) {
     {
       bic_code: 'UOVBSGSG351',
       account_number: '3513220403',
       account_name: 'Juan de la Cruz',
-      amount: 43.35
+      amount: amount
     }
   }
 
@@ -19,17 +20,26 @@ describe UOB::Payroll::TXTFile::Row do
   it { expect(string_version).to eq expected_content }
 
   describe "formatted_amount" do
-    let(:params) {
-      {
-       bic_code: 'UOVBSGSG351',
-       account_number: '3513220403',
-       account_name: 'Juan de la Cruz',
-       amount: "2000.565"
-      }
-    }
+    describe "with an amount as a string param" do
+      let(:amount) { "2000.565" }
 
-    it "returns a proper value" do
-      expect(row.formatted_amount).to eq "0000000200057"
+      it "returns a proper value" do
+        expect(row.formatted_amount).to eq "0000000200057"
+      end
+    end
+    describe "with an amount as a float param" do
+      let(:amount) { 2000.565 }
+
+      it "returns a proper value" do
+        expect(row.formatted_amount).to eq "0000000200057"
+      end
+    end
+    describe "with an amount as a big decimal param" do
+      let(:amount) { BigDecimal("2000.565") }
+
+      it "returns a proper value" do
+        expect(row.formatted_amount).to eq "0000000200057"
+      end
     end
   end
 end

--- a/spec/uob/payroll/txt_file/row_spec.rb
+++ b/spec/uob/payroll/txt_file/row_spec.rb
@@ -17,4 +17,19 @@ describe UOB::Payroll::TXTFile::Row do
   let(:expected_content) { File.read 'spec/fixtures/row_sample.txt'}
 
   it { expect(string_version).to eq expected_content }
+
+  describe "formatted_amount" do
+    let(:params) {
+      {
+       bic_code: 'UOVBSGSG351',
+       account_number: '3513220403',
+       account_name: 'Juan de la Cruz',
+       amount: "2000.565"
+      }
+    }
+
+    it "returns a proper value" do
+      expect(row.formatted_amount).to eq "0000000200057"
+    end
+  end
 end


### PR DESCRIPTION
Using ruby 2.2, the format used to round automatically, Now with ruby 2.4, it only truncates
```
# using 2.4
(byebug)  amount = BigDecimal("2000.565")
 => #<BigDecimal:5620153a0a30,'0.2000565E4',18(18)> 
(byebug)  (format '%014.2f', amount).gsub('.','')
"0000000200056"
(byebug)  (format '%014.2f', amount.round(2)).gsub('.','')
"0000000200057"
(byebug) 
```
with 2.2, result is same